### PR TITLE
Specify the version of pycolmap in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN python3 -m pip install --upgrade pip
 RUN pip3 install setuptools
 RUN pip3 install torch torchvision
 RUN pip3 install -e .
-RUN pip3 install pycolmap
+RUN pip3 install pycolmap==0.6.1
 
 # Running the tests:
 RUN python -m pytest  


### PR DESCRIPTION
I specify the version of pycolmap. The version of pycolmap became 3.10.0 in Jul 26, 2024.
Current deep-image-matching optimizes with a lower vesion like 0.6.1, if pycolmap is 3.10 we can't build the docker image