### PR TITLE
More flexible cameras.yaml

### DIFF
--- a/config/cameras.yaml
+++ b/config/cameras.yaml
@@ -2,11 +2,19 @@ general:
   camera_model: "pinhole" # ["simple-pinhole", "pinhole", "simple-radial", "opencv"]
   openmvg_camera_model: "pinhole_radial_k3" # ["pinhole", "pinhole_radial_k3", "pinhole_brown_t2"]
   single_camera: True
+  intrinsics: ~  # None
 
 cam0:
   camera_model: "pinhole"
-  images : ""
+  intrinsics: [
+    481.14, 478.43, 481.44, 383.72
+  ]
+  images : "cam0_*.jpg"
 
 cam1:
-  camera_model: "pinhole"
-  images : "DSC_6468.jpg,DSC_6468.jpg"
+  camera_model: "opencv"
+  intrinsics: [
+    481.91, 482.20, 482.70, 384.33,
+    0.0, 0.0, 0.0, 0.0
+  ]
+  images : "cam1_*.jpg"

--- a/docs/agisoft_metashape.md
+++ b/docs/agisoft_metashape.md
@@ -31,8 +31,8 @@ Therefore, you may have to rotate the reconstruction or to use Ground Control Po
 ![](./assets/metashape_reconstruction.png)
 
 Opening an image, you can also see the keypoints and the matches between the images.
-Note, that the Bunlder camera model is a simple pinhole camera model, so the radial distortion is not taken into account. 
-Therefore, you may see large reprojection errors in the images.
+Note, that the Bunlder camera model is a simple pinhole camera model, with only the focal length and two radial distortion parameters.
+Therefore, you will probably see large reprojection errors in the images.
 To fix this, you should import your camera calibration according to the Metashape camera model and run the bundle adjustment (optimization) again.
 
 ![](./assets/metashape_keypoints.png)

--- a/docs/camera_models.md
+++ b/docs/camera_models.md
@@ -4,14 +4,19 @@ For the COLMAP database, by default, DIM assigns camera models to images based o
 
 For images not assigned to specific `cam<x>` camera groups, the options specified under `general` are applied. The `camera_model` can be selected from `["simple-pinhole", "pinhole", "simple-radial", "opencv"]`. It's worth noting that it's easily possible to extend this to include all the classical COLMAP camera models. Cameras can either be shared among all images (`single_camera == True`), or each camera can have a different camera model (`single_camera == False`).
 
-A subset of images can share intrinsics using `cam<x>` key, by specifying the `camera_model` along with the names of the images separated by commas.
-Note that you must specify the full image name, including the extension.
+A subset of images can share intrinsics using `cam<x>` key, by specifying the `camera_model` along with the names of the images separated by commas, and the `intrinsics` corresponding to the `camera_model`.
+
+Note that you must specify the full image name, including the extension. Image name supports globbing, so you can use `*` to match multiple images.
+
+If you want to read intrinsics from the EXIF data, you can set the `intrinsics` to `~` (null).
+
 For instance:
 
 ```python
 cam0:
   camera_model: "pinhole"
-  images: "DSC_6468.jpg,DSC_6469.jpg"
+  images: "DSC_64*.jpg,DSC_65*.jpg"
+  intrinsics: [481.14, 478.43, 481.44, 383.72]
 ```
 
 There's no limit to the number of `cam<x>` entries you can use, just add them following the provided format.
@@ -23,14 +28,22 @@ general:
   camera_model: "pinhole" # ["simple-pinhole", "pinhole", "simple-radial", "opencv"]
   openmvg_camera_model: "pinhole_radial_k3" # ["pinhole", "pinhole_radial_k3", "pinhole_brown_t2"]
   single_camera: True
+  intrinsics: ~
 
 cam0:
   camera_model: "pinhole"
-  images : ""
+  intrinsics: [
+    481.14, 478.43, 481.44, 383.72
+  ]
+  images : "cam0_*.jpg"
 
 cam1:
-  camera_model: "pinhole"
-  images : "DSC_6468.jpg,DSC_6468.jpg"
+  camera_model: "opencv"
+  intrinsics: [
+    481.91, 482.20, 482.70, 384.33,
+    0.0, 0.0, 0.0, 0.0
+  ]
+  images : "cam1_*.jpg"
 ```
 
 For OpenMVG and MICMAC, refer to their respective sections.

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,19 +31,10 @@ matcher:
   th: 0.85
 ```
 
-### Default configuration
-
-Note that all the defaults configurations of DIM, including local features, matchers and geometric verification, are in `src/deep_image_matching/config.py`.
-
-
-<!--
-**Page under construction...**
+### The Config Class
 
 ::: deep_image_matching.config.Config
     options:
       show_root_heading: true
       show_source: false
       members:
--->
-
-

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ Example: `python main.py --dir ./assets/example_cyprus --pipeline superpoint+lig
 
 Other optional parameters are:
 
-- `--config_file` `-c`: the path to the YAML configuration file containing the custom configuration. See the [Advanced configuration](#advanced-configuration) section (default: `None`, so default configuration is used)
+- `--config_file` `-c`: the path to the YAML configuration file containing the custom configuration. See the [Advanced configuration](./advanced_configuration.md) section (default: `None`, so default configuration is used)
 - `--strategy` `-s`: the strategy to use for matching the images. It can be `matching_lowres`, `bruteforce`, `sequential`, `retrieval`, `custom_pairs`. See [Matching strategies](#matching-strategies) section (default: `matching_lowres`)
 - `--quality` `-q`: the quality of the images to be matched. It can be `lowest`, `low`, `medium`, `high` or `highest`. See [Quality](#quality) section (default: `high`).
 - `tiling` `-t`: if passed, the images are tiled in 4 parts and each part is matched separately. This is useful for high-resolution images if you do not want to resize them. See [Tiling](#tiling) section (default: `None`).
@@ -53,7 +53,6 @@ The GUI loads the available configurations from [`config.py`](https://github.com
 ### From Jupyter notebooks
 
 If you want to use Deep_Image_Matching from a Jupyter notebook, you can check the examples in the [`notebooks`](https://github.com/3DOM-FBK/deep-image-matching/tree/master/notebooks) folder.
-
 
 ## Pipelines
 
@@ -130,4 +129,3 @@ If you want to run the matching by tile, you can choose different approaches for
 - `exhaustive`: the images are divided into a regular grid of size 2400x2000 px to extract the features. The matching is carried out by matching all the possible combinations of tiles (brute-force). This method can be very slow for large images or in combination with the `highest` quality option and, in some cases, it may lead to error in the geometric verification if too many wrong matches are detected.
 
 To control the tile size and the tile overlap, refer to the [Advanced configuration](./advanced_configuration.md) section.
-

--- a/src/deep_image_matching/hloc/utils/database.py
+++ b/src/deep_image_matching/hloc/utils/database.py
@@ -31,10 +31,10 @@
 
 # This script is based on an original implementation by True Price.
 
-import sys
 import sqlite3
-import numpy as np
+import sys
 
+import numpy as np
 
 IS_PYTHON3 = sys.version_info[0] >= 3
 
@@ -68,9 +68,7 @@ CREATE_IMAGES_TABLE = """CREATE TABLE IF NOT EXISTS images (
     prior_tz REAL,
     CONSTRAINT image_id_check CHECK(image_id >= 0 and image_id < {}),
     FOREIGN KEY(camera_id) REFERENCES cameras(camera_id))
-""".format(
-    MAX_IMAGE_ID
-)
+""".format(MAX_IMAGE_ID)
 
 CREATE_TWO_VIEW_GEOMETRIES_TABLE = """
 CREATE TABLE IF NOT EXISTS two_view_geometries (
@@ -183,8 +181,8 @@ class COLMAPDatabase(sqlite3.Connection):
         self,
         name,
         camera_id,
-        prior_q=np.full(4, np.NaN),
-        prior_t=np.full(3, np.NaN),
+        prior_q=np.full(4, np.nan),
+        prior_t=np.full(3, np.nan),
         image_id=None,
     ):
         cursor = self.execute(
@@ -277,8 +275,8 @@ class COLMAPDatabase(sqlite3.Connection):
 
 
 def example_usage():
-    import os
     import argparse
+    import os
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--database_path", default="database.db")

--- a/src/deep_image_matching/hloc/utils/database.py
+++ b/src/deep_image_matching/hloc/utils/database.py
@@ -32,11 +32,8 @@
 # This script is based on an original implementation by True Price.
 
 import sqlite3
-import sys
 
 import numpy as np
-
-IS_PYTHON3 = sys.version_info[0] >= 3
 
 MAX_IMAGE_ID = 2**31 - 1
 

--- a/src/deep_image_matching/hloc/utils/database.py
+++ b/src/deep_image_matching/hloc/utils/database.py
@@ -123,17 +123,11 @@ def pair_id_to_image_ids(pair_id):
 
 
 def array_to_blob(array):
-    if IS_PYTHON3:
-        return array.tobytes()
-    else:
-        return np.getbuffer(array)
+    return array.tobytes()
 
 
 def blob_to_array(blob, dtype, shape=(-1,)):
-    if IS_PYTHON3:
-        return np.fromstring(blob, dtype=dtype).reshape(*shape)
-    else:
-        return np.frombuffer(blob, dtype=dtype).reshape(*shape)
+    return np.frombuffer(blob, dtype=dtype).reshape(*shape)
 
 
 class COLMAPDatabase(sqlite3.Connection):

--- a/src/deep_image_matching/utils/database.py
+++ b/src/deep_image_matching/utils/database.py
@@ -32,11 +32,8 @@
 # This script is based on an original implementation by True Price.
 
 import sqlite3
-import sys
 
 import numpy as np
-
-IS_PYTHON3 = sys.version_info[0] >= 3
 
 MAX_IMAGE_ID = 2**31 - 1
 
@@ -68,9 +65,7 @@ CREATE_IMAGES_TABLE = """CREATE TABLE IF NOT EXISTS images (
     prior_tz REAL,
     CONSTRAINT image_id_check CHECK(image_id >= 0 and image_id < {}),
     FOREIGN KEY(camera_id) REFERENCES cameras(camera_id))
-""".format(
-    MAX_IMAGE_ID
-)
+""".format(MAX_IMAGE_ID)
 
 CREATE_TWO_VIEW_GEOMETRIES_TABLE = """
 CREATE TABLE IF NOT EXISTS two_view_geometries (
@@ -126,17 +121,11 @@ def pair_id_to_image_ids(pair_id):
 
 
 def array_to_blob(array):
-    if IS_PYTHON3:
-        return array.tostring()
-    else:
-        return np.getbuffer(array)
+    return array.tobytes()
 
 
 def blob_to_array(blob, dtype, shape=(-1,)):
-    if IS_PYTHON3:
-        return np.fromstring(blob, dtype=dtype).reshape(*shape)
-    else:
-        return np.frombuffer(blob, dtype=dtype).reshape(*shape)
+    return np.frombuffer(blob, dtype=dtype).reshape(*shape)
 
 
 class COLMAPDatabase(sqlite3.Connection):
@@ -295,11 +284,9 @@ def example_usage():
     args = parser.parse_args()
 
     if os.path.exists(args.database_path):
-        print("ERROR: database path already exists -- will not modify it.")
-        return
+        os.remove(args.database_path)
 
     # Open the database.
-
     db = COLMAPDatabase.connect(args.database_path)
 
     # For convenience, try creating all the tables upfront.
@@ -413,6 +400,8 @@ def example_usage():
 
     if os.path.exists(args.database_path):
         os.remove(args.database_path)
+
+    print("All tests passed.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed `h5_to_db.py`, `cameras.yaml` now supports globbing and custom intrinsics.

Example:
```yaml
general:
  camera_model: "pinhole" # ["simple-pinhole", "pinhole", "simple-radial", "opencv"]
  openmvg_camera_model: "pinhole_radial_k3" # ["pinhole", "pinhole_radial_k3", "pinhole_brown_t2"]
  single_camera: True
  intrinsics: ~  # None

cam0:
  camera_model: "pinhole"
  intrinsics: [
    481.14, 478.43, 481.44, 383.72
  ]
  images : "cam0_*.jpg"

cam1:
  camera_model: "opencv"
  intrinsics: [
    481.91, 482.20, 482.70, 384.33,
    0.0, 0.0, 0.0, 0.0
  ]
  images : "cam1_*.jpg"
```