### PR TITLE
update the sequential matching

### DIFF
--- a/src/deep_image_matching/pairs_generator.py
+++ b/src/deep_image_matching/pairs_generator.py
@@ -22,9 +22,11 @@ def pairs_from_sequential(
     img_list: List[Union[str, Path]], overlap: int
 ) -> List[tuple]:
     pairs = []
-    for i in range(len(img_list) - overlap):
+    for i in range(len(img_list)):
         for k in range(overlap):
             j = i + k + 1
+            if j >= len(img_list):
+                break
             im1 = img_list[i]
             im2 = img_list[j]
             pairs.append((im1, im2))


### PR DESCRIPTION
The current sequential matching only matches the indices starting between `[0, len(img_list)-overlap)`. This commit completes the sequential matching, allowing images after `len(img_list)-overlap`